### PR TITLE
Dartdoc comment cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-#Dart wrapper library for [facebook/react](http://facebook.github.io/)
+# Dart wrapper library for [facebook/react](http://facebook.github.io/)
 
 [![Pub](https://img.shields.io/pub/v/react.svg)](https://pub.dartlang.org/packages/react)
+[![documentation](https://img.shields.io/badge/Documentation-react-blue.svg)](https://www.dartdocs.org/documentation/react/latest/)
 
-##Getting started
+## Getting started
 
-If you are not familiar with React library read [react tutorial](http://facebook.github.io/react/docs/getting-started.html) first.
+If you are not familiar with the ReactJS library, read this [react tutorial](http://facebook.github.io/react/docs/getting-started.html) first.
 
 To integrate in Dart project add dependency [react](https://pub.dartlang.org/packages/react) to pubspec.yaml.
 
@@ -46,7 +47,7 @@ Inverse method to rendering component is `unmountComponentAtNode`
   reactDom.unmountComponentAtNode(querySelector('#content'));
 ```
 
-##Using browser native elements
+## Using browser native elements
 
 If you are familiar with React (without JSX extension) React-dart shouldn't surprise you much. All elements are defined as
 functions that take `props` as first argument and `children` as optional second argument. `props` should implement `Map` and `children` is either one React element or `List` with multiple elements.
@@ -65,7 +66,7 @@ For event handlers you must provide function that take `SyntheticEvent` (defined
 div({"onClick": (SyntheticMouseEvent e) => print(e)})
 ```
 
-##Defining custom elements
+## Defining custom elements
 
 Define custom class that extends Component and implements at least render.
 
@@ -104,7 +105,7 @@ class MyComponent extends Component {
 myComponent({"text":"Somehting"})
 ```
 
-####Creating components with richer interface than just props and children and with type control
+#### Creating components with richer interface than just props and children and with type control
 
 ```dart
 typedef MyComponentType({String headline, String text});

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -2,32 +2,33 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/**
- * A Dart library for building user interfaces.
- */
+/// A Dart library for building UI using ReactJS.
 library react;
 
+/// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
+/// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)
 abstract class Component {
+  /// ReactJS [Component] props.
   Map props;
 
+  /// Provides access to the underlying DOM representation of the [render]ed [Component].
   dynamic ref;
+
   dynamic getDOMNode;
+
   dynamic _jsRedraw;
+
   dynamic _jsThis;
 
-  /**
-   * The JavaScript `ReactComponent` instance associated with this component.
-   */
+  /// The JavaScript [`ReactComponent`](https://facebook.github.io/react/docs/top-level-api.html#reactdom.render)
+  /// instance of this [Component] returned by [render].
   dynamic get jsThis => _jsThis;
 
-  /**
-   * Getter to allow the [displayName] React property to be set.
-   */
+  /// Allows the [ReactJS `displayName` property](https://facebook.github.io/react/docs/component-specs.html#displayname)
+  /// to be set for debugging purposes.
   String get displayName => runtimeType.toString();
 
-  /**
-   * Bind the value of input to [state[key]].
-   */
+  /// Bind the value of input to [state[key]].
   bind(key) => [state[key], (value) => setState({key: value})];
 
   initComponentInternal(props, _jsRedraw, [ref, getDOMNode, _jsThis]) {
@@ -46,34 +47,34 @@ abstract class Component {
 
   initStateInternal() {
     this.state = new Map.from(getInitialState());
-    /** Call transferComponent to get state also to _prevState */
+    // Call transferComponent to get state also to _prevState
     transferComponentState();
   }
 
+  /// ReactJS [Component] state.
   Map state = {};
 
-  /**
-   * private _nextState and _prevState are usefull for methods shouldComponentUpdate,
-   * componentWillUpdate and componentDidUpdate.
-   *
-   * Use of theese private variables is implemented in react_client or react_server
-   */
+  /// Private reference to the value of [state] from the previous render cycle.
+  ///
+  /// Useful for ReactJS lifecycle methods [shouldComponentUpdate], [componentWillUpdate] and [componentDidUpdate].
   Map _prevState = null;
+
+  /// Private reference to the value of [state] for the upcoming render cycle.
+  ///
+  /// Useful for ReactJS lifecycle methods [shouldComponentUpdate], [componentWillUpdate] and [componentDidUpdate].
   Map _nextState = null;
-  /**
-   * nextState and prevState are just getters for previous private variables _prevState
-   * and _nextState
-   *
-   * if _nextState is null, then next state will be same as actual state,
-   * so return state as nextState
-   */
+
+  /// Public getter for [_prevState].
   Map get prevState => _prevState;
+
+  /// Public getter for [_nextState].
+  ///
+  /// If `null`, then [_nextState] is equal to [state] - which is the value that will be returned.
   Map get nextState => _nextState == null ? state : _nextState;
 
-  /**
-   * Transfers component _nextState to state and state to _prevState.
-   * This is only way how to set _prevState.
-   */
+  /// Transfers [Component] [_nextState] to [state], and [state] to [_prevState].
+  ///
+  /// This is the only way to set the value of [_prevState].
   void transferComponentState() {
     _prevState = state;
     if (_nextState != null) {
@@ -82,14 +83,16 @@ abstract class Component {
     _nextState = new Map.from(state);
   }
 
+  /// Force a call to [render] by calling [setState], which effectively "redraws" the [Component].
+  ///
+  /// [A.k.a "forceUpdate"](https://facebook.github.io/react/docs/component-api.html#forceupdate)
   void redraw() {
     setState({});
   }
 
-  /**
-   * set _nextState to state updated by newState
-   * and call React original setState method with no parameter
-   */
+  /// Set [_nextState] to provided [newState] value and force a re-render.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-api.html#setstate>
   void setState(Map newState) {
     if (newState != null) {
       _nextState.addAll(newState);
@@ -98,58 +101,204 @@ abstract class Component {
     _jsRedraw();
   }
 
-  /**
-   * set _nextState to newState
-   * and call React original setState method with no parameter
-   */
+  /// Set [_nextState] to provided [newState] value and force a re-render.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-api.html#replacestate>
   void replaceState(Map newState) {
     Map nextState = newState == null ? {} : new Map.from(newState);
     _nextState = nextState;
+
     _jsRedraw();
   }
 
+  /// ReactJS lifecycle method that is invoked once, both on the client and server, immediately before the initial
+  /// rendering occurs.
+  ///
+  /// If you call [setState] within this method, [render] will see the updated state and will be executed only once
+  /// despite the [state] value change.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#mounting-componentwillmount>
   void componentWillMount() {}
 
+  /// ReactJS lifecycle method that is invoked once, only on the client _(not on the server)_, immediately after the
+  /// initial rendering occurs.
+  ///
+  /// At this point in the lifecycle, you can access any [ref]s to the children of [rootNode].
+  ///
+  /// The [componentDidMount] method of child [Component]s is invoked _before_ that of parent [Component].
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#mounting-componentdidmount>
   void componentDidMount(/*DOMElement */ rootNode) {}
 
+  /// ReactJS lifecycle method that is invoked when a [Component] is receiving [newProps].
+  ///
+  /// This method is not called for the initial [render].
+  ///
+  /// Use this as an opportunity to react to a prop transition before [render] is called by updating the [state] using
+  /// [setState]. The old props can be accessed via [props].
+  ///
+  /// Calling [setState] within this function will not trigger an additional [render].
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentwillreceiveprops>
   void componentWillReceiveProps(newProps) {}
 
+  /// ReactJS lifecycle method that is invoked before rendering when [nextProps] or [nextState] are being received.
+  ///
+  /// This method is not called for the initial [render] or when [redraw] _a.k.a "forceUpdate"_ is used.
+  ///
+  /// Use this as an opportunity to return false when you're certain that the transition to the new props and state
+  /// will not require a component update.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate>
   bool shouldComponentUpdate(nextProps, nextState) => true;
 
+  /// ReactJS lifecycle method that is invoked immediately before rendering when [nextProps] or [nextState] are being
+  /// received.
+  ///
+  /// This method is not called for the initial [render].
+  ///
+  /// Use this as an opportunity to perform preparation before an update occurs.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentwillupdate>
   void componentWillUpdate(nextProps, nextState) {}
 
+  /// ReactJS lifecycle method that is invoked immediately after the [Component]'s updates are flushed to the DOM.
+  ///
+  /// This method is not called for the initial [render].
+  ///
+  /// Use this as an opportunity to operate on the [rootNode] (DOM) when the [Component] has been updated as a result
+  /// of the values of [prevProps] / [prevState].
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentdidupdate>
   void componentDidUpdate(prevProps, prevState, /*DOMElement */ rootNode) {}
 
+  /// ReactJS lifecycle method that is invoked immediately before a [Component] is unmounted from the DOM.
+  ///
+  /// Perform any necessary cleanup in this method, such as invalidating timers or cleaning up any DOM [Element]s that
+  /// were created in [componentDidMount].
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#unmounting-componentwillunmount>
   void componentWillUnmount() {}
 
+  /// Invoked once before the [Component] is mounted. The return value will be used as the initial value of [state].
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#getinitialstate>
   Map getInitialState() => {};
 
+  /// Invoked once and cached when [reactComponentClass] is called. Values in the mapping will be set on [props]
+  /// if that prop is not specified by the parent component.
+  ///
+  /// This method is invoked before any instances are created and thus cannot rely on [props]. In addition, be aware
+  /// that any complex objects returned by `getDefaultProps` will be shared across instances, not copied.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#getdefaultprops>
   Map getDefaultProps() => {};
 
+  /// __Required.__
+  ///
+  /// When called, it should examine [props] and [state] and return a single child [Element]. This child [Element] can
+  /// be either a virtual representation of a native DOM component (such as [DivElement]) or another composite
+  /// [Component] that you've defined yourself.
+  ///
+  /// See: <https://facebook.github.io/react/docs/component-specs.html#render>
   dynamic render();
-
 }
 
-/** Synthetic event */
 
+/// A cross-browser wrapper around the browser's [nativeEvent].
+///
+/// It has the same interface as the browser's native event, including [stopPropagation] and [preventDefault], except
+/// the events work identically across all browsers.
+///
+/// See: <https://facebook.github.io/react/docs/events.html#syntheticevent>
 class SyntheticEvent {
-
+  /// Indicates whether the [Event] bubbles up through the DOM or not.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/bubbles>
   final bool bubbles;
+
+  /// Indicates whether the [Event] is cancelable or not.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable>
   final bool cancelable;
+
+  /// Identifies the current target for the event, as the [Event] traverses the DOM.
+  ///
+  /// It always refers to the [Element] the [Event] handler has been attached to as opposed to [target] which identifies
+  /// the [Element] on which the [Event] occurred.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget>
   final /*DOMEventTarget*/ currentTarget;
+
   bool _defaultPrevented;
+
   dynamic _preventDefault;
-  final dynamic stopPropagation;
+
+  /// Indicates whether or not [preventDefault] was called on the event.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/defaultPrevented>
   bool get defaultPrevented => _defaultPrevented;
-  final num eventPhase;
-  final bool isTrusted;
-  final /*DOMEvent*/ nativeEvent;
+
+  /// Cancels the [Event] if it is [cancelable], without stopping further propagation of the event.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault>
   void preventDefault() {
     _defaultPrevented = true;
     _preventDefault();
   }
+
+  /// Prevents further propagation of the current event.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation>
+  final dynamic stopPropagation;
+
+  /// Indicates which phase of the [Event] flow is currently being evaluated.
+  ///
+  /// Possible values:
+  ///
+  /// > [Event.CAPTURING_PHASE] (1) - The [Event] is being propagated through the [target]'s ancestor objects. This
+  /// process starts with the Window, then [HtmlDocument], then the [HtmlHtmlElement], and so on through the [Element]s
+  /// until the [target]'s parent is reached. Event listeners registered for capture mode when
+  /// [EventTarget.addEventListener] was called are triggered during this phase.
+  ///
+  /// > [Event.AT_TARGET] (2) - The [Event] has arrived at the [target]. Event listeners registered for this phase are
+  /// called at this time. If [bubbles] is `false`, processing the [Event] is finished after this phase is complete.
+  ///
+  /// > [Event.BUBBLING_PHASE] (3) - The [Event] is propagating back up through the [target]'s ancestors in reverse
+  /// order, starting with the parent, and eventually reaching the containing Window. This is known as bubbling, and
+  /// occurs only if [bubbles] is `true`. [Event] listeners registered for this phase are triggered during this process.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase>
+  final num eventPhase;
+
+  /// Is `true` when the [Event] was generated by a user action, and `false` when the [Event] was created or modified
+  /// by a script or dispatched via [Event.dispatchEvent].
+  ///
+  /// __Read Only__
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted>
+  final bool isTrusted;
+
+  /// Native browser event that [SyntheticEvent] wraps around.
+  final /*DOMEvent*/ nativeEvent;
+
+  /// A reference to the object that dispatched the event. It is different from [currentTarget] when the [Event]
+  /// handler is called when [eventPhase] is [Event.BUBBLING_PHASE] or [Event.CAPTURING_PHASE].
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/target>
   final /*DOMEventTarget*/ target;
+
+  /// Returns the [Time] (in milliseconds) at which the [Event] was created.
+  ///
+  /// _Starting with Chrome 49, returns a high-resolution monotonic time instead of epoch time._
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp>
   final num timeStamp;
+
+  /// Returns a string containing the type of event. It is set when the [Event] is constructed and is the name commonly
+  /// used to refer to the specific event.
+  ///
+  /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/type>
   final String type;
 
   SyntheticEvent(
@@ -313,72 +462,433 @@ class SyntheticWheelEvent extends SyntheticEvent {
 
 }
 
-/**
- * client side rendering
- */
+/// Client side rendering.
 @deprecated
 var render = (component, element) {
   throw new Exception('setClientConfiguration must be called before render.');
 };
 
-/**
- * server side rendering
- */
+/// Server side rendering.
 @deprecated
 var renderToString;
 
-/**
- * Similar to [renderToString], except this doesn't create extra DOM attributes such as
- * `data-react-id`, that React uses internally. This is useful if you want to use React
- * as a simple static page generator, as stripping away the extra attributes can save
- * lots of bytes.
- */
+/// Similar to [renderToString], except this doesn't create extra DOM attributes such as
+/// `data-react-id`, that ReactJS uses internally. This is useful if you want to use React
+/// as a simple static page generator, as stripping away the extra attributes can save
+/// lots of bytes.
 @deprecated
 var renderToStaticMarkup;
 
-
-/**
- * bool unmountComponentAtNode(HTMLElement);
- *
- * client side derendering - reverse operation to render
- *
- */
+/// Inverse of [render].
 @deprecated
 var unmountComponentAtNode;
 
-/**
- * register component method to register component on both, client-side and server-side.
- */
+/// Registers [componentFactory] on both client and server.
 var registerComponent = (componentFactory, [skipMethods]) {
   throw new Exception('setClientConfiguration must be called before registerComponent.');
 };
 
-/**
- * if this component has been mounted into the DOM, this returns the corresponding native browser DOM element.
- */
+/// Returns the corresponding native browser DOM [Element] if the [Component] has been mounted into the DOM.
 @deprecated
 var findDOMNode;
 
-/** Basic DOM elements
- * <var> is renamed to <variable> because var is reserved word in Dart.
- */
-var a, abbr, address, area, article, aside, audio, b, base, bdi, bdo, big, blockquote, body, br,
-button, canvas, caption, cite, code, col, colgroup, data, datalist, dd, del, details, dfn, dialog,
-div, dl, dt, em, embed, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6,
-head, header, hr, html, i, iframe, img, input, ins, kbd, keygen, label, legend, li, link, main,
-map, mark, menu, menuitem, meta, meter, nav, noscript, object, ol, optgroup, option, output,
-p, param, picture, pre, progress, q, rp, rt, ruby, s, samp, script, section, select, small, source,
-span, strong, style, sub, summary, sup, table, tbody, td, textarea, tfoot, th, thead, time,
-title, tr, track, u, ul, variable, video, wbr;
+/// The HTML `<a>` [AnchorElement].
+var a;
 
-/** SVG elements */
-var circle, clipPath, defs, ellipse, g, image, line, linearGradient, mask, path, pattern, polygon,
-polyline, radialGradient, rect, stop, svg, text, tspan;
+/// The HTML `<abbr>` [Element].
+var abbr;
+
+/// The HTML `<address>` [Element].
+var address;
+
+/// The HTML `<area>` [AreaElement].
+var area;
+
+/// The HTML `<article>` [Element].
+var article;
+
+/// The HTML `<aside>` [Element].
+var aside;
+
+/// The HTML `<audio>` [AudioElement].
+var audio;
+
+/// The HTML `<b>` [Element].
+var b;
+
+/// The HTML `<base>` [BaseElement].
+var base;
+
+/// The HTML `<bdi>` [Element].
+var bdi;
+
+/// The HTML `<bdo>` [Element].
+var bdo;
+
+/// The HTML `<big>` [Element].
+var big;
+
+/// The HTML `<blockquote>` [Element].
+var blockquote;
+
+/// The HTML `<body>` [BodyElement].
+var body;
+
+/// The HTML `<br>` [BRElement].
+var br;
+
+/// The HTML `<button>` [ButtonElement].
+var button;
+
+/// The HTML `<canvas>` [CanvasElement].
+var canvas;
+
+/// The HTML `<caption>` [Element].
+var caption;
+
+/// The HTML `<cite>` [Element].
+var cite;
+
+/// The HTML `<code>` [Element].
+var code;
+
+/// The HTML `<col>` [Element].
+var col;
+
+/// The HTML `<colgroup>` [Element].
+var colgroup;
+
+/// The HTML `<data>` [Element].
+var data;
+
+/// The HTML `<datalist>` [DataListElement].
+var datalist;
+
+/// The HTML `<dd>` [Element].
+var dd;
+
+/// The HTML `<del>` [Element].
+var del;
+
+/// The HTML `<details>` [DetailsElement].
+var details;
+
+/// The HTML `<dfn>` [Element].
+var dfn;
+
+/// The HTML `<dialog>` [DialogElement].
+var dialog;
+
+/// The HTML `<div>` [DivElement].
+var div;
+
+/// The HTML `<dl>` [DListElement].
+var dl;
+
+/// The HTML `<dt>` [Element].
+var dt;
+
+/// The HTML `<em>` [Element].
+var em;
+
+/// The HTML `<embed>` [EmbedElement].
+var embed;
+
+/// The HTML `<fieldset>` [FieldSetElement].
+var fieldset;
+
+/// The HTML `<figcaption>` [Element].
+var figcaption;
+
+/// The HTML `<figure>` [Element].
+var figure;
+
+/// The HTML `<footer>` [Element].
+var footer;
+
+/// The HTML `<form>` [FormElement].
+var form;
+
+/// The HTML `<h1>` [HeadingElement].
+var h1;
+
+/// The HTML `<h2>` [HeadingElement].
+var h2;
+
+/// The HTML `<h3>` [HeadingElement].
+var h3;
+
+/// The HTML `<h4>` [HeadingElement].
+var h4;
+
+/// The HTML `<h5>` [HeadingElement].
+var h5;
+
+/// The HTML `<h6>` [HeadingElement].
+var h6;
+
+/// The HTML `<head>` [HeadElement].
+var head;
+
+/// The HTML `<header>` [Element].
+var header;
+
+/// The HTML `<hr>` [HRElement].
+var hr;
+
+/// The HTML `<html>` [HtmlHtmlElement].
+var html;
+
+/// The HTML `<i>` [Element].
+var i;
+
+/// The HTML `<iframe>` [IFrameElement].
+var iframe;
+
+/// The HTML `<img>` [ImageElement].
+var img;
+
+/// The HTML `<input>` [InputElement].
+var input;
+
+/// The HTML `<ins>` [Element].
+var ins;
+
+/// The HTML `<kbd>` [Element].
+var kbd;
+
+/// The HTML `<keygen>` [KeygenElement].
+var keygen;
+
+/// The HTML `<label>` [LabelElement].
+var label;
+
+/// The HTML `<legend>` [LegendElement].
+var legend;
+
+/// The HTML `<li>` [LIElement].
+var li;
+
+/// The HTML `<link>` [LinkElement].
+var link;
+
+/// The HTML `<main>` [Element].
+var main;
+
+/// The HTML `<map>` [MapElement].
+var map;
+
+/// The HTML `<mark>` [Element].
+var mark;
+
+/// The HTML `<menu>` [MenuElement].
+var menu;
+
+/// The HTML `<menuitem>` [MenuItemElement].
+var menuitem;
+
+/// The HTML `<meta>` [MetaElement].
+var meta;
+
+/// The HTML `<meter>` [MeterElement].
+var meter;
+
+/// The HTML `<nav>` [Element].
+var nav;
+
+/// The HTML `<noscript>` [Element].
+var noscript;
+
+/// The HTML `<object>` [ObjectElement].
+var object;
+
+/// The HTML `<ol>` [OListElement].
+var ol;
+
+/// The HTML `<optgroup>` [OptGroupElement].
+var optgroup;
+
+/// The HTML `<option>` [OptionElement].
+var option;
+
+/// The HTML `<output>` [OutputElement].
+var output;
+
+/// The HTML `<p>` [ParagraphElement].
+var p;
+
+/// The HTML `<param>` [ParamElement].
+var param;
+
+/// The HTML `<picture>` [PictureElement].
+var picture;
+
+/// The HTML `<pre>` [PreElement].
+var pre;
+
+/// The HTML `<progress>` [ProgressElement].
+var progress;
+
+/// The HTML `<q>` [QuoteElement].
+var q;
+
+/// The HTML `<rp>` [Element].
+var rp;
+
+/// The HTML `<rt>` [Element].
+var rt;
+
+/// The HTML `<ruby>` [Element].
+var ruby;
+
+/// The HTML `<s>` [Element].
+var s;
+
+/// The HTML `<samp>` [Element].
+var samp;
+
+/// The HTML `<script>` [ScriptElement].
+var script;
+
+/// The HTML `<section>` [Element].
+var section;
+
+/// The HTML `<select>` [SelectElement].
+var select;
+
+/// The HTML `<small>` [Element].
+var small;
+
+/// The HTML `<source>` [SourceElement].
+var source;
+
+/// The HTML `<span>` [SpanElement].
+var span;
+
+/// The HTML `<strong>` [Element].
+var strong;
+
+/// The HTML `<style>` [StyleElement].
+var style;
+
+/// The HTML `<sub>` [Element].
+var sub;
+
+/// The HTML `<summary>` [Element].
+var summary;
+
+/// The HTML `<sup>` [Element].
+var sup;
+
+/// The HTML `<table>` [TableElement].
+var table;
+
+/// The HTML `<tbody>` [TableSectionElement].
+var tbody;
+
+/// The HTML `<td>` [TableCellElement].
+var td;
+
+/// The HTML `<textarea>` [TextAreaElement].
+var textarea;
+
+/// The HTML `<tfoot>` [TableSectionElement].
+var tfoot;
+
+/// The HTML `<th>` [TableCellElement].
+var th;
+
+/// The HTML `<thead>` [TableSectionElement].
+var thead;
+
+/// The HTML `<time>` [TimeInputElement].
+var time;
+
+/// The HTML `<title>` [TitleElement].
+var title;
+
+/// The HTML `<tr>` [TableRowElement].
+var tr;
+
+/// The HTML `<track>` [TrackElement].
+var track;
+
+/// The HTML `<u>` [Element].
+var u;
+
+/// The HTML `<ul>` [UListElement].
+var ul;
+
+/// The HTML `<var>` [Element].
+///
+/// _Named variable because `var` is a reserved word in Dart._
+var variable;
+
+/// The HTML `<video>` [VideoElement].
+var video;
+
+/// The HTML `<wbr>` [Element].
+var wbr;
+
+/// The SVG `<circle>` [CircleElement].
+var circle;
+
+/// The SVG `<clipPath>` [ClipPathElement].
+var clipPath;
+
+/// The SVG `<defs>` [DefsElement].
+var defs;
+
+/// The SVG `<ellipse>` [EllipseElement].
+var ellipse;
+
+/// The SVG `<g>` [GElement].
+var g;
+
+/// The SVG `<image>` [ImageElement].
+var image;
+
+/// The SVG `<line>` [LineElement].
+var line;
+
+/// The SVG `<linearGradient>` [LinearGradientElement].
+var linearGradient;
+
+/// The SVG `<mask>` [MaskElement].
+var mask;
+
+/// The SVG `<path>` [PathElement].
+var path;
+
+/// The SVG `<pattern>` [PatternElement].
+var pattern;
+
+/// The SVG `<polygon>` [PolygonElement].
+var polygon;
+
+/// The SVG `<polyline>` [PolylineElement].
+var polyline;
+
+/// The SVG `<radialGradient>` [RadialGradientElement].
+var radialGradient;
+
+/// The SVG `<rect>` [RectElement].
+var rect;
+
+/// The SVG `<stop>` [StopElement].
+var stop;
+
+/// The SVG `<svg>` [SvgSvgElement].
+var svg;
+
+/// The SVG `<text>` [TextElement].
+var text;
+
+/// The SVG `<tspan>` [TSpanElement].
+var tspan;
 
 
-/**
- * Create DOM components by creator passed
- */
+/// Create React DOM [Component]s by calling the specified [creator]
 _createDOMComponents(creator){
   a = creator('a');
   abbr = creator('abbr');
@@ -515,11 +1025,10 @@ _createDOMComponents(creator){
   tspan = creator('tspan');
 }
 
-/**
- * set configuration based on passed functions.
- *
- * It pass arguments to global variables and run DOM components creation by dom Creator.
- */
+/// Set configuration based on functions provided as arguments.
+///
+/// The arguments are assigned to global variables, and React DOM [Component]s are created by calling
+/// [_createDOMComponents] with [domCreator].
 setReactConfiguration(domCreator, customRegisterComponent, customRender, customRenderToString,
     customRenderToStaticMarkup, customUnmountComponentAtNode, customFindDOMNode){
   registerComponent = customRegisterComponent;
@@ -531,4 +1040,3 @@ setReactConfiguration(domCreator, customRegisterComponent, customRender, customR
   // HTML Elements
   _createDOMComponents(domCreator);
 }
-

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -40,49 +40,35 @@ newJsMap(Map map) {
   return JsMap;
 }
 
-/**
- * Type of [children] must be child or list of childs, when child is JsObject or String
- */
+/// Type of [children] must be child or list of children, when child is [JsObject] or [String]
 typedef JsObject ReactComponentFactory(Map props, [dynamic children]);
 typedef Component ComponentFactory();
 
-/**
- * The type of a ref specified as a callback.
- *
- * See <https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute>.
- */
+/// The type of [Component.ref] specified as a callback.
+///
+/// See: <https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute>
 typedef _CallbackRef(componentOrDomNode);
 
-/**
- * A Dart function that creates React JS component instances.
- */
+/// Creates ReactJS [Component] instances.
 abstract class ReactComponentFactoryProxy implements Function {
-  /**
-   * The type of component created by this factory.
-   */
+  /// The type of [Component] created by this factory.
   get type;
 
-  /**
-   * Returns a new rendered component instance with the specified props and children.
-   */
+  /// Returns a new rendered [Component] instance with the specified [props] and [children].
   JsObject call(Map props, [dynamic children]);
 
-  /**
-   * Used to implement a variadic version of [call], in which children may be specified as additional options.
-   */
+  /// Used to implement a variadic version of [call], in which children may be specified as additional arguments.
   dynamic noSuchMethod(Invocation invocation);
 }
 
-/**
- * A Dart function that creates React JS component instances for Dart components.
- */
+/// Creates ReactJS [Component] instances for Dart components.
 class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
   final JsFunction reactClass;
   final JsFunction reactComponentFactory;
 
   ReactDartComponentFactoryProxy(JsFunction reactClass) :
-    this.reactClass = reactClass,
-    this.reactComponentFactory = _React.callMethod('createFactory', [reactClass]);
+      this.reactClass = reactClass,
+      this.reactComponentFactory = _React.callMethod('createFactory', [reactClass]);
 
   JsFunction get type => reactClass;
 
@@ -116,10 +102,8 @@ class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
     return super.noSuchMethod(invocation);
   }
 
-  /**
-   * Returns a JsObject version of the specified props, preprocessed for consumption by React JS
-   * and prepared for consumption by the react-dart wrapper internals.
-   */
+  /// Returns a [JsObject] version of the specified [props], preprocessed for consumption by ReactJS and prepared for
+  /// consumption by the [react] library internals.
   static JsObject generateExtendedJsProps(Map props, dynamic children) {
     if (children == null) {
       children = [];
@@ -132,18 +116,17 @@ class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
 
     JsObject jsProps = newJsObjectEmpty();
 
-    /**
-     * Transfer over key and ref if they're specified so React JS knows about them.
-     */
+    // Transfer over `key` if specified so ReactJS knows about it.
     if (extendedProps.containsKey('key')) {
       jsProps['key'] = extendedProps['key'];
     }
 
+    // Transfer over `ref` if specified so ReactJS knows about it.
     if (extendedProps.containsKey('ref')) {
       var ref = extendedProps['ref'];
 
-      // If the ref is a callback, pass React a function that will call it
-      // with the Dart component instance, not the JsObject instance.
+      // If the ref is a callback, pass ReactJS a function that will call it
+      // with the Dart Component instance, not the JsObject instance.
       if (ref is _CallbackRef) {
         jsProps['ref'] = (JsObject instance) => ref(instance == null ? null : _getComponent(instance));
       } else {
@@ -151,45 +134,33 @@ class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
       }
     }
 
-    /**
-     * Put Dart props inside the internal object.
-     */
+    // Put Dart props inside the `__internal__` object.
     jsProps[INTERNAL] = {PROPS: extendedProps};
 
     return jsProps;
   }
 }
 
-/** TODO Think about using Expandos */
+// TODO Think about using Expandos
 _getInternal(JsObject jsThis) => jsThis[PROPS][INTERNAL];
 _getProps(JsObject jsThis) => _getInternal(jsThis)[PROPS];
 _getComponent(JsObject jsThis) => _getInternal(jsThis)[COMPONENT];
 _getInternalProps(JsObject jsProps) => jsProps[INTERNAL][PROPS];
 
+
+/// Returns a new [ReactComponentFactory] which produces a new JS
+/// [`ReactClass` component class](https://facebook.github.io/react/docs/top-level-api.html#react.createclass).
 ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Iterable<String> skipMethods = const []]) {
 
   var zone = Zone.current;
 
-  /**
-   * wrapper for getDefaultProps.
-   * Get internal, create component and place it to internal.
-   *
-   * Next get default props by component method and merge component.props into it
-   * to update it with passed props from parent.
-   *
-   * @return jsProsp with internal with component.props and component
-   */
+  /// Wrapper for [Component.getDefaultProps].
   var getDefaultProps = new JsFunction.withThis((jsThis) => zone.run(() {
     return newJsObjectEmpty();
   }));
 
-  /**
-   * get initial state from component.getInitialState, put them to state.
-   *
-   * @return empty JsObject as default state for javascript react component
-   */
+  /// Wrapper for [Component.getInitialState].
   var getInitialState = new JsFunction.withThis((jsThis) => zone.run(() {
-
     var internal = _getInternal(jsThis);
     var redraw = () {
       if (internal[IS_MOUNTED]) {
@@ -221,9 +192,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
     return newJsObjectEmpty();
   }));
 
-  /**
-   * only wrap componentWillMount
-   */
+  /// Wrapper for [Component.componentWillMount].
   var componentWillMount = new JsFunction.withThis((jsThis) => zone.run(() {
     _getInternal(jsThis)[IS_MOUNTED] = true;
     _getComponent(jsThis)
@@ -231,9 +200,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
         ..transferComponentState();
   }));
 
-  /**
-   * only wrap componentDidMount
-   */
+  /// Wrapper for [Component.componentDidMount].
   var componentDidMount = new JsFunction.withThis((JsObject jsThis) => zone.run(() {
     //you need to get dom node by calling findDOMNode
     var rootNode = _ReactDom.callMethod('findDOMNode', [jsThis]);
@@ -247,98 +214,88 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
       ..addAll(newProps != null ? newProps : {});
   }
 
+  /// 1. Add [component] to [newArgs] to keep it in [INTERNAL]
+  /// 2. Update [Component.props] using [newArgs] as second argument to [_getNextProps]
+  /// 3. Update [Component.state] by calling [Component.transferComponentState]
   _afterPropsChange(Component component, newArgs) {
-    /** add component to newArgs to keep component in internal */
+    // [1]
     newArgs[INTERNAL][COMPONENT] = component;
 
-    /** update component.props */
+    // [2]
     component.props = _getNextProps(component, newArgs);
 
-    /** update component.state */
+    // [3]
     component.transferComponentState();
   }
 
-  /**
-   * Wrap componentWillReceiveProps
-   */
-  var componentWillReceiveProps =
-      new JsFunction.withThis((jsThis, newArgs, [reactInternal]) => zone.run(() {
-    var component = _getComponent(jsThis);
+  /// Wrapper for [Component.componentWillReceiveProps].
+  var componentWillReceiveProps = new JsFunction.withThis((jsThis, newArgs, [reactInternal]) => zone.run(() {
+    Component component = _getComponent(jsThis);
     component.componentWillReceiveProps(_getNextProps(component, newArgs));
   }));
 
-  /**
-   * count nextProps from jsNextProps, get result from component,
-   * and if shoudln't update, update props and transfer state.
-   */
-  var shouldComponentUpdate =
-      new JsFunction.withThis((jsThis, newArgs, nextState, nextContext) => zone.run(() {
+  /// Wrapper for [Component.shouldComponentUpdate].
+  var shouldComponentUpdate = new JsFunction.withThis((jsThis, newArgs, nextState, nextContext) => zone.run(() {
     Component component  = _getComponent(jsThis);
-    /** use component.nextState where are stored nextState */
-    if (component.shouldComponentUpdate(_getNextProps(component, newArgs),
-                                        component.nextState)) {
+
+    if (component.shouldComponentUpdate(_getNextProps(component, newArgs), component.nextState)) {
       return true;
     } else {
-      /**
-       * if component shouldnt update, update props and tranfer state,
-       * becasue willUpdate will not be called and so it will not do it.
-       */
+      // If component should not update, update props / transfer state because componentWillUpdate will not be called.
       _afterPropsChange(component, newArgs);
       return false;
     }
   }));
 
-  /**
-   * wrap component.componentWillUpdate and after that update props and transfer state
-   */
-  var componentWillUpdate =
-      new JsFunction.withThis((jsThis, newArgs, nextState, [reactInternal]) => zone.run(() {
+  /// Wrapper for [Component.componentWillUpdate].
+  var componentWillUpdate = new JsFunction.withThis((jsThis, newArgs, nextState, [reactInternal]) => zone.run(() {
     Component component  = _getComponent(jsThis);
-    component.componentWillUpdate(_getNextProps(component, newArgs),
-                                  component.nextState);
+
+    component.componentWillUpdate(_getNextProps(component, newArgs), component.nextState);
+
     _afterPropsChange(component, newArgs);
   }));
 
-  /**
-   * wrap componentDidUpdate and use component.prevState which was trasnfered from state in componentWillUpdate.
-   */
-  var componentDidUpdate =
-      new JsFunction.withThis((JsObject jsThis, prevProps, prevState, prevContext) => zone.run(() {
+  /// Wrapper for [Component.componentDidUpdate].
+  ///
+  /// Uses [prevState] which was transferred from [Component.nextState] in [componentWillUpdate].
+  var componentDidUpdate = new JsFunction.withThis((JsObject jsThis, prevProps, prevState, prevContext) => zone.run(() {
     var prevInternalProps = _getInternalProps(prevProps);
-    //you don't get root node as parameter but need to get it directly
+    // You don't get rootNode as a parameter, so we need to get it directly
     var rootNode = _ReactDom.callMethod('findDOMNode', [jsThis]);
     Component component = _getComponent(jsThis);
     component.componentDidUpdate(prevInternalProps, component.prevState, rootNode);
   }));
 
-  /**
-   * only wrap componentWillUnmount
-   */
-  var componentWillUnmount =
-      new JsFunction.withThis((jsThis, [reactInternal]) => zone.run(() {
+  /// Wrapper for [Component.componentWillUnmount].
+  var componentWillUnmount = new JsFunction.withThis((jsThis, [reactInternal]) => zone.run(() {
     _getInternal(jsThis)[IS_MOUNTED] = false;
-    _getComponent(jsThis).componentWillUnmount();
+    Component component = _getComponent(jsThis);
+    component.componentWillUnmount();
   }));
 
-  /**
-   * only wrap render
-   */
+  /// Wrapper for [Component.render].
   var render = new JsFunction.withThis((jsThis) => zone.run(() {
-    return _getComponent(jsThis).render();
+    Component component = _getComponent(jsThis);
+
+    return component.render();
   }));
 
-  var skipableMethods = ['componentDidMount', 'componentWillReceiveProps',
-                         'shouldComponentUpdate', 'componentDidUpdate',
-                         'componentWillUnmount'];
+  var skippableMethods = [
+    'componentDidMount',
+    'componentWillReceiveProps',
+    'shouldComponentUpdate',
+    'componentDidUpdate',
+    'componentWillUnmount',
+  ];
 
   removeUnusedMethods(Map originalMap, Iterable removeMethods) {
-    removeMethods.where((m) => skipableMethods.contains(m)).forEach((m) => originalMap.remove(m));
+    removeMethods.where((m) => skippableMethods.contains(m)).forEach((m) => originalMap.remove(m));
     return originalMap;
   }
 
-  /**
-   * create reactComponent with wrapped functions
-   */
+  /// Create the JS [`ReactClass` component class](https://facebook.github.io/react/docs/top-level-api.html#react.createclass)
+  /// with wrapped functions.
   JsFunction reactComponentClass = _React.callMethod('createClass', [newJsMap(
     removeUnusedMethods({
       'displayName': componentFactory().displayName,
@@ -355,20 +312,14 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
     }, skipMethods)
   )]);
 
-  /**
-   * return ReactComponentFactory which produce react component with set props and children[s]
-   */
   return new ReactDartComponentFactoryProxy(reactComponentClass);
 }
 
-/**
- * A Dart function that creates React JS component instances for DOM components.
- */
+/// Creates ReactJS [Component] instances for DOM components.
 class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
-  /**
-   * The name of the proxied DOM component.
-   * E.g., 'div', 'a', 'h1'
-   */
+  /// The name of the proxied DOM component.
+  ///
+  /// E.g. `'div'`, `'a'`, `'h1'`
   final String name;
   ReactDomComponentFactoryProxy(this.name);
 
@@ -408,39 +359,33 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
     return super.noSuchMethod(invocation);
   }
 
-  /**
-   * Prepares the bound values, event handlers, and style props for consumption by React JS DOM components.
-   */
+  /// Prepares the bound values, event handlers, and style props for consumption by ReactJS DOM components.
   static void convertProps(Map props) {
     _convertBoundValues(props);
     _convertEventHandlers(props);
+
     if (props.containsKey('style')) {
       props['style'] = new JsObject.jsify(props['style']);
     }
   }
 }
 
-/**
- * create dart-react registered component for html tag.
- */
+/// Create react-dart registered component for the HTML [Element].
 _reactDom(String name) {
   return new ReactDomComponentFactoryProxy(name);
 }
 
-/**
- * Recognize if type of input (or other element) is checkbox by it's props.
- */
+/// Returns whether an [InputElement] is a [CheckboxInputElement] based the value of the `type` key in [props].
 _isCheckbox(props) {
   return props['type'] == 'checkbox';
 }
 
-/**
- * get value from DOM element.
- *
- * If element is checkbox, return bool, else return value of "value" attribute
- */
+/// Get value from the provided [domElem].
+///
+/// If the [domElem] is an [CheckboxInputElement], return [bool], else return [String] value.
 _getValueFromDom(domElem) {
   var props = domElem.attributes;
+
   if (_isCheckbox(props)) {
     return domElem.checked;
   } else {
@@ -448,11 +393,9 @@ _getValueFromDom(domElem) {
   }
 }
 
-/**
- * set value to props based on type of input.
- *
- * Specialy, it recognized chceckbox.
- */
+/// Set value to props based on type of input.
+///
+/// Specifically, it recognized checkbox.
 _setValueToProps(Map props, val) {
   if (_isCheckbox(props)) {
     if(val) {
@@ -467,36 +410,29 @@ _setValueToProps(Map props, val) {
   }
 }
 
-/**
- * convert bound values to pure value
- * and packed onchanged function
- */
+/// Convert bound values to pure value and packed onChange function
 _convertBoundValues(Map args) {
   var boundValue = args['value'];
-  if (args['value'] is List) {
+
+  if (boundValue is List) {
     _setValueToProps(args, boundValue[0]);
     args['value'] = boundValue[0];
     var onChange = args["onChange"];
-    /**
-     * put new function into onChange event hanlder.
-     *
-     * If there was something listening for taht event,
-     * trigger it and return it's return value.
-     */
-    args['onChange'] = (e) {
-      boundValue[1](_getValueFromDom(e.target));
-      if(onChange != null)
-        return onChange(e);
+
+    // Put new function into onChange event handler.
+    // If there was something listening for that event, trigger it and return it's return value.
+    args['onChange'] = (event) {
+      boundValue[1](_getValueFromDom(event.target));
+
+      if (onChange != null) {
+        return onChange(event);
+      }
     };
   }
 }
 
-
-/**
- * Convert event pack event handler into wrapper
- * and pass it only dart object of event
- * converted from JsObject of event.
- */
+/// Convert packed event handler into wrapper and pass it only the Dart [Event] object converted from the [JsObject]
+/// event.
 _convertEventHandlers(Map args) {
   var zone = Zone.current;
   args.forEach((key, value) {
@@ -505,6 +441,7 @@ _convertEventHandlers(Map args) {
       return;
     }
     var eventFactory;
+
     if (_syntheticClipboardEvents.contains(key)) {
       eventFactory = syntheticClipboardEventFactory;
     } else if (_syntheticKeyboardEvents.contains(key)) {
@@ -521,13 +458,17 @@ _convertEventHandlers(Map args) {
       eventFactory = syntheticUIEventFactory;
     } else if (_syntheticWheelEvents.contains(key)) {
       eventFactory = syntheticWheelEventFactory;
-    } else return;
+    } else {
+      return;
+    }
+
     args[key] = (JsObject e, [String domId, Event event]) => zone.run(() {
       value(eventFactory(e));
     });
   });
 }
 
+/// Wrapper for [SyntheticEvent].
 SyntheticEvent syntheticEventFactory(JsObject e) {
   return new SyntheticEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
@@ -535,14 +476,16 @@ SyntheticEvent syntheticEventFactory(JsObject e) {
       e["target"], e["timeStamp"], e["type"]);
 }
 
-SyntheticEvent syntheticClipboardEventFactory(JsObject e) {
+/// Wrapper for [SyntheticClipboardEvent].
+SyntheticClipboardEvent syntheticClipboardEventFactory(JsObject e) {
   return new SyntheticClipboardEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
       e["target"], e["timeStamp"], e["type"], e["clipboardData"]);
 }
 
-SyntheticEvent syntheticKeyboardEventFactory(JsObject e) {
+/// Wrapper for [SyntheticKeyboardEvent].
+SyntheticKeyboardEvent syntheticKeyboardEventFactory(JsObject e) {
   return new SyntheticKeyboardEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"],
@@ -551,20 +494,23 @@ SyntheticEvent syntheticKeyboardEventFactory(JsObject e) {
       e["key"], e["keyCode"], e["metaKey"], e["repeat"], e["shiftKey"]);
 }
 
-SyntheticEvent syntheticFocusEventFactory(JsObject e) {
+/// Wrapper for [SyntheticFocusEvent].
+SyntheticFocusEvent syntheticFocusEventFactory(JsObject e) {
   return new SyntheticFocusEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
       e["target"], e["timeStamp"], e["type"], e["relatedTarget"]);
 }
 
-SyntheticEvent syntheticFormEventFactory(JsObject e) {
+/// Wrapper for [SyntheticFormEvent].
+SyntheticFormEvent syntheticFormEventFactory(JsObject e) {
   return new SyntheticFormEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
       e["target"], e["timeStamp"], e["type"]);
 }
 
+/// Wrapper for [SyntheticDataTransfer].
 SyntheticDataTransfer syntheticDataTransferFactory(JsObject dt) {
   if (dt == null) return null;
   List<File> files = [];
@@ -590,7 +536,8 @@ SyntheticDataTransfer syntheticDataTransferFactory(JsObject dt) {
   return new SyntheticDataTransfer(dt["dropEffect"], effectAllowed, files, types);
 }
 
-SyntheticEvent syntheticMouseEventFactory(JsObject e) {
+/// Wrapper for [SyntheticMouseEvent].
+SyntheticMouseEvent syntheticMouseEventFactory(JsObject e) {
   SyntheticDataTransfer dt = syntheticDataTransferFactory(e["dataTransfer"]);
   return new SyntheticMouseEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
@@ -600,7 +547,8 @@ SyntheticEvent syntheticMouseEventFactory(JsObject e) {
       e["screenY"], e["shiftKey"]);
 }
 
-SyntheticEvent syntheticTouchEventFactory(JsObject e) {
+/// Wrapper for [SyntheticTouchEvent].
+SyntheticTouchEvent syntheticTouchEventFactory(JsObject e) {
   return new SyntheticTouchEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
@@ -608,14 +556,16 @@ SyntheticEvent syntheticTouchEventFactory(JsObject e) {
       e["shiftKey"], e["targetTouches"], e["touches"]);
 }
 
-SyntheticEvent syntheticUIEventFactory(JsObject e) {
+/// Wrapper for [SyntheticUIEvent].
+SyntheticUIEvent syntheticUIEventFactory(JsObject e) {
   return new SyntheticUIEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
       e["target"], e["timeStamp"], e["type"], e["detail"], e["view"]);
 }
 
-SyntheticEvent syntheticWheelEventFactory(JsObject e) {
+/// Wrapper for [SyntheticWheelEvent].
+SyntheticWheelEvent syntheticWheelEventFactory(JsObject e) {
   return new SyntheticWheelEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
@@ -624,30 +574,25 @@ SyntheticEvent syntheticWheelEventFactory(JsObject e) {
 
 Set _syntheticClipboardEvents = new Set.from(["onCopy", "onCut", "onPaste",]);
 
-Set _syntheticKeyboardEvents = new Set.from(["onKeyDown", "onKeyPress",
-    "onKeyUp",]);
+Set _syntheticKeyboardEvents = new Set.from(["onKeyDown", "onKeyPress", "onKeyUp",]);
 
 Set _syntheticFocusEvents = new Set.from(["onFocus", "onBlur",]);
 
-Set _syntheticFormEvents = new Set.from(["onChange", "onInput", "onSubmit",
-    "onReset",
+Set _syntheticFormEvents = new Set.from(["onChange", "onInput", "onSubmit", "onReset",]);
+
+Set _syntheticMouseEvents = new Set.from(["onClick", "onContextMenu", "onDoubleClick", "onDrag", "onDragEnd",
+    "onDragEnter", "onDragExit", "onDragLeave", "onDragOver", "onDragStart", "onDrop", "onMouseDown", "onMouseEnter",
+    "onMouseLeave", "onMouseMove", "onMouseOut", "onMouseOver", "onMouseUp",
 ]);
 
-Set _syntheticMouseEvents = new Set.from(["onClick", "onContextMenu",
-    "onDoubleClick", "onDrag", "onDragEnd", "onDragEnter", "onDragExit",
-    "onDragLeave", "onDragOver", "onDragStart", "onDrop", "onMouseDown",
-    "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseOut",
-    "onMouseOver", "onMouseUp",]);
-
-Set _syntheticTouchEvents = new Set.from(["onTouchCancel", "onTouchEnd",
-    "onTouchMove", "onTouchStart",]);
+Set _syntheticTouchEvents = new Set.from(["onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart",]);
 
 Set _syntheticUIEvents = new Set.from(["onScroll",]);
 
 Set _syntheticWheelEvents = new Set.from(["onWheel",]);
 
 
-JsObject _render(JsObject component, HtmlElement element) {
+JsObject _render(JsObject component, Element element) {
   var renderedComponent = _ReactDom.callMethod('render', [component, element]);
 
   if (renderedComponent is JsObject) return renderedComponent;
@@ -679,8 +624,8 @@ void setClientConfiguration() {
     throw new Exception('react.js and react_dom.js must be loaded.');
   }
 
-  setReactConfiguration(_reactDom, _registerComponent, _render, _renderToString,
-      _renderToStaticMarkup, _unmountComponentAtNode, _findDomNode);
+  setReactConfiguration(_reactDom, _registerComponent, _render, _renderToString, _renderToStaticMarkup,
+      _unmountComponentAtNode, _findDomNode);
   setReactDOMConfiguration(_render, _unmountComponentAtNode, _findDomNode);
   setReactDOMServerConfiguration(_renderToString, _renderToStaticMarkup);
 }

--- a/lib/react_dom.dart
+++ b/lib/react_dom.dart
@@ -9,12 +9,12 @@ var render = (component, element) {
   throw new Exception('setClientConfiguration must be called before render.');
 };
 
-/// Removes a mounted React component from the DOM and cleans up its event handlers and state. If no component
+/// Removes a mounted React [Component] from the DOM and cleans up its event handlers and state. If no component
 /// was mounted in the container, calling this function does nothing. Returns true if a component was unmounted
 /// and false if there was no component to unmount.
 var unmountComponentAtNode;
 
-/// If this component has been mounted into the DOM, this returns the corresponding native browser DOM element.
+/// If the [Component] has been mounted into the DOM, this returns the corresponding native browser DOM [Element].
 var findDOMNode;
 
 /// Sets configuration based on passed functions.

--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -4,15 +4,14 @@
 
 library react_server;
 
-import "package:react/react.dart";
-import "package:react/react_dom_server.dart";
 import "dart:math";
-import "package:quiver/iterables.dart";
 import 'dart:typed_data';
 
-/**
- * important constants geted from react.js needed to create correct checksum
- */
+import "package:react/react.dart";
+import "package:react/react_dom_server.dart";
+import "package:quiver/iterables.dart";
+
+// ReactJS constants needed to create correct checksum
 String _SEPARATOR = ".";
 String _ID_ATTR_NAME = "data-reactid";
 String _CHECKSUM_ATTR_NAME = "data-react-checksum";
@@ -25,120 +24,72 @@ typedef String OwnerFactory([String ownerId, num position, String key]);
 typedef OwnerFactory ReactComponentFactory(Map props, [dynamic children]);
 typedef Component ComponentFactory();
 
-/**
- * register component will create method, which create new Component,
- * run lifecycle methods and return it's render method result
- */
+/// Creates a method that which creates a new [Component], runs lifecycle methods and returns the result of
+/// [Component.render].
 ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Iterable<String> skipMethods = const []]) {
-  /**
-   * return ReactComponentFactory which produce react component with seted props and
-   * children[s] and return it's render method result
-   */
   return (Map props, [dynamic children]) {
     Component component = componentFactory();
 
-    /**
-     * get default props, add children to props and apply props from arguments
-     */
+    // Get default props, add children to props and apply props from arguments
     props['children'] = children;
     component.initComponentInternal(props, () {});
 
-    /**
-     * get initial state and run componentWillMount lifecycle method
-     */
+    // Get initial state
     component.initStateInternal();
     component.componentWillMount();
 
-    /**
-     * if component will mount called setState or replaceState, then transfer
-     * this state to actual state.
-     */
+    // If componentWillMount called setState or replaceState, then transfer this state to actual state.
     component.transferComponentState();
 
-    /**
-     * return component render method result. (it should be string)
-     */
-    return ([String ownerId, num position, String key]) {return component.render()(ownerId, position, key);};
+    // Return result of component.render()
+    return ([String ownerId, num position, String key]) {
+      return component.render()(ownerId, position, key);
+    };
   };
-
 }
 
-
-
-/**
- * create basic dom component factory
- */
+/// Create DOM component factory
 ReactComponentFactory _reactDom(String name) {
   return (Map args, [children]) {
-    /**
-     * pack component string creating into function to easy pass owner id,
-     * position and key (from its' custom component owner)
-     */
+    // Pack component string creating into function to easy pass owner id, position and key
+    // (from its custom component owner)
     return ([String ownerId, int position, String key]) {
-      /**
-       * unpair elements can't have children
-       */
-      if (_unPairElements.contains(name) && (children != null && children.length > 0)) {
-        throw new Exception();
+      if (_selfClosingElementTags.contains(name) && (children != null && children.length > 0)) {
+        throw new Exception('$name element does not accept children.');
       }
 
-      /**
-       * count react id
-       *
-       * if args contains key, then replace argument key by that key.
-       */
+      // Count react id
+      // If args contains key, then replace argument key by that key.
       if (args.containsKey("key")) {
         key = args["key"].toString();
       }
 
-      /**
-       * if ownerId is not set, than this is root and create rootId to it.
-       */
+      // If ownerId is not set, then this is a rootNode - create rootId for it.
       String thisId;
       if (ownerId == null) {
         thisId = _createRootId();
       } else {
-        /**
-         * else append adequate string to parent id based on position and key.
-         */
+        // If ownerId is set, append adequate string to parent id based on position and key.
         thisId = ownerId + (key != null ? ".\$$key" : (position != null ? ".${position.toRadixString(36)}" : ".0"));
       }
 
-      /**
-       * create stringbuffer to build result
-       *
-       * end open tag to it
-       */
+      // Create StringBuffer to build result, end open tag to it
       StringBuffer result = new StringBuffer("<$name");
 
-      /**
-       * add attributes to it and prepare args to be
-       * same as in react.js
-       */
+      // Add attributes to it and prepare args to be the same as in ReactJS
       args.forEach((key,value) {
         String toWrite = _parseDomArgument(key, value);
         if(toWrite != null) result.write(toWrite);
       });
 
-      /**
-       * add id after attributes
-       */
+      // Add id after attributes
       result.write(' $_ID_ATTR_NAME="$thisId"');
 
-      /**
-       * if element is not pair, then close it
-       */
-      if (_unPairElements.contains(name)) {
-        result.write(">");
-      } else {
-        /**
-         * close open tag
-         */
-        result.write(">");
+      // Close the opening tag
+      result.write(">");
 
-        /**
-         * add children (if children is list)
-         */
+      // If its not a self-closing tag... add children
+      if (!_selfClosingElementTags.contains(name)) {
         if (children is Iterable) {
           enumerate(children.where((child) => child!=null)).forEach((value) {
             num i = value.index;
@@ -150,11 +101,6 @@ ReactComponentFactory _reactDom(String name) {
             }
           });
         } else if (children != null) {
-          /**
-           * or child (if childre is not list and not null
-           *
-           * if it is string, add it as it is, if not, add it as component
-           */
           if (children is String) {
             result.write(_escapeTextForBrowser(children));
           } else if (children is Function) {
@@ -163,42 +109,31 @@ ReactComponentFactory _reactDom(String name) {
             result.write(children);
           }
         }
-        /**
-         * and add close tag
-         */
+
+        // Add a closing tag after the children
         result.write("</$name>");
       }
 
-      /**
-       * return result as strin
-       */
+      // Return result as a string
       return result.toString();
     };
   };
 }
 
-/**
- * convert DOM arguments (delete event handlers and key)
- */
+/// Convert DOM arguments (delete event handlers and [key])
 String _parseDomArgument(String key, dynamic value) {
   if(value == null) return '';
-  /**
-   * synthetic events must not pass to string and key too
-   */
+  // Synthetic events must not pass to string and key too
   if(_syntheticEvents.contains(key)) return null;
   if(key == 'key') return null;
   if(key == 'ref') return null;
 
-  /**
-   * change "className" for class
-   */
+  // Change "className" to class
   if (key == "className") {
     key = 'class';
   }
 
-  /**
-   * change "htmlFor" for "for"
-   */
+  // Change "htmlFor" to "for"
   if (key == "htmlFor") {
     key = 'for';
   }
@@ -232,59 +167,38 @@ String _escaper(Match match) {
   return _ESCAPE_LOOKUP[match.group(0)];
 }
 
-/**
- * Escapes text to prevent scripting attacks.
- * Same as in react.js
- *
- * @param {*} text Text value to escape.
- * @return {string} An escaped string.
- */
+/// Escapes [text] to prevent scripting attacks.
 String _escapeTextForBrowser(text) {
   return ('' + text).replaceAllMapped(_ESCAPE_REGEX, _escaper);
 }
 
-/**
- * set of all in client converted synthetic events
- */
-Set _syntheticEvents = new Set.from(["onCopy", "onCut", "onPaste",
-    "onKeyDown", "onKeyPress", "onKeyUp", "onFocus", "onBlur",
-    "onChange", "onInput", "onSubmit", "onClick", "onDoubleClick",
-    "onDrag", "onDragEnd", "onDragEnter", "onDragExit", "onDragLeave",
-    "onDragOver", "onDragStart", "onDrop", "onMouseDown", "onMouseEnter",
-    "onMouseLeave", "onMouseMove", "onMouseOut", "onMouseOver", "onMouseUp",
-    "onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart", "onScroll",
-    "onWheel",]);
+/// Set of all in client converted synthetic events
+Set _syntheticEvents = new Set.from([
+  "onCopy", "onCut", "onPaste", "onKeyDown", "onKeyPress", "onKeyUp", "onFocus", "onBlur", "onChange", "onInput",
+  "onSubmit", "onClick", "onDoubleClick", "onDrag", "onDragEnd", "onDragEnter", "onDragExit", "onDragLeave",
+  "onDragOver", "onDragStart", "onDrop", "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseOut",
+  "onMouseOver", "onMouseUp", "onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart", "onScroll", "onWheel",
+]);
 
-/**
- * set of al pair elements tags ( which are not void elements )
- */
-Set _pairElements = new Set.from(["a", "abbr", "address", "article", "aside", "audio",
-    "b", "bdi", "bdo", "big", "blockquote", "body", "button", "canvas", "caption",
-    "cite", "code", "colgroup", "data", "datalist", "dd", "del", "details", "dfn",
-    "dialog", "div", "dl", "dt", "em", "fieldset", "figcaption", "figure", "footer",
-    "form", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "html", "i", "iframe",
-    "ins", "kbd", "label", "legend", "li", "main", "map", "mark", "menu", "menuitem",
-    "meter", "nav", "noscript", "object", "ol", "optgroup", "option", "output", "p",
-    "picture", "pre", "progress", "q", "rp", "rt", "ruby", "s", "samp", "script", "section",
-    "select", "small", "span", "strong", "style", "sub", "summary", "sup", "table",
-    "tbody", "td", "textarea", "tfoot", "th", "thead", "time", "title", "tr", "u",
-    "ul", "variable", "video",
-    /** SVG elements */
-    "defs", "g", "linearGradient", "mask", "pattern", "radialGradient", "svg", "text",
-    "tspan",]);
+/// Set of HTML [Element] names that can contain children
+Set _elementTags = new Set.from([
+  "a", "abbr", "address", "article", "aside", "audio", "b", "bdi", "bdo", "big", "blockquote", "body", "button",
+  "canvas", "caption", "cite", "code", "colgroup", "data", "datalist", "dd", "del", "details", "dfn", "dialog", "div",
+  "dl", "dt", "em", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "head",
+  "header", "html", "i", "iframe", "ins", "kbd", "label", "legend", "li", "main", "map", "mark", "menu", "menuitem",
+  "meter", "nav", "noscript", "object", "ol", "optgroup", "option", "output", "p", "picture", "pre", "progress", "q",
+  "rp", "rt", "ruby", "s", "samp", "script", "section", "select", "small", "span", "strong", "style", "sub", "summary",
+  "sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "time", "title", "tr", "u", "ul", "variable",
+  "video", "defs", "g", "linearGradient", "mask", "pattern", "radialGradient", "svg", "text", "tspan",
+]);
 
-/**
- * set of empty elements tags based on http://www.w3.org/TR/html-markup/syntax.html#void-element
- */
-Set _unPairElements = new Set.from(["area", "base", "br", "col", "hr", "img", "input", "link",
-    "meta", "param", "command", "embed", "keygen", "source","track", "wbr",
-    /** SVG elements */
-    "circle", "ellipse", "line", "path", "polygon", "polyline", "rect", "stop",]);
+/// Set of HTML [Element] names that are "self-closing"
+Set _selfClosingElementTags = new Set.from([
+  "area", "base", "br", "col", "hr", "img", "input", "link", "meta", "param", "command", "embed", "keygen", "source",
+  "track", "wbr", "circle", "ellipse", "line", "path", "polygon", "polyline", "rect", "stop",
+]);
 
 
-/**
- * render component method
- */
 String _renderComponentToString(OwnerFactory component) {
   return _addChecksumToMarkup(component());
 }
@@ -293,24 +207,19 @@ String _renderToStaticMarkup(OwnerFactory component) {
   return _removeReactIdFromMarkup(component());
 }
 
-/**
- * creates random id based on id creation in react.js
- */
+/// Creates random id based on id creation in react.js
 String _createRootId() {
   var rng = new Random();
   return "${_SEPARATOR}r[${rng.nextInt(_GLOBAL_MOUNT_POINT_MAX).toRadixString(36)}]";
 }
 
-/**
- * count checksumm and add it to markup as last attribute of root element
- */
+/// Count checksum and add it to markup as last attribute of root element
 String _addChecksumToMarkup(String markup) {
   var checksum = _adler32(markup);
   return markup.replaceFirst(
       '>',
       ' $_CHECKSUM_ATTR_NAME="$checksum">'
-    );
-
+  );
 }
 
 String _removeReactIdFromMarkup(String markup) {
@@ -318,12 +227,11 @@ String _removeReactIdFromMarkup(String markup) {
   return markup.replaceAll(matcher, "");
 }
 
-/**
- * checksum algorithm copied from react.js
- * ( must be the same to enable react.js recognize it as ok)
- * javacript uses 4-byte signed integers for binary operations
- * while dart adjusts it, so Int32x4 is used for it
- */
+/// Checksum algorithm copied from react.js
+///
+/// Must be the same to enable react.js recognize it.
+///
+/// JS uses 4-byte signed integers for binary operations while dart adjusts it, so Int32x4 is used for it
 _adler32(String data) {
   int a = 1;
   int b = 0;


### PR DESCRIPTION
1. Change comments to use `///` style as recommended by Dart.
2. Link to known entities where possible.
3. Attempt to clean up descriptions / grammar.

Not sure how important this is to us - but it's at least a starting point.
